### PR TITLE
Plugin API RFC

### DIFF
--- a/rfcs/xxxx-plugin-api.md
+++ b/rfcs/xxxx-plugin-api.md
@@ -1,0 +1,9 @@
+- Start Date: 2020-12-08
+
+# Summary
+
+This RFC introduces a programmatic API for plugin developpers.
+
+## Content
+
+You can read the full RFC [here](https://plugin-api-rfc.vercel.app/)


### PR DESCRIPTION
## Plugin API RFC

This PR introduces the Plugin API.

Because of the size of this RFC it lives outside this repository. 

You can read it [here](https://plugin-api-rfc.vercel.app)
