### PR TITLE
Add options object to custom field attributes

### DIFF
--- a/rfcs/xxxx-custom-fields-api.md
+++ b/rfcs/xxxx-custom-fields-api.md
@@ -169,7 +169,7 @@ register(app) {
                 id: 'color-picker.color.format.label',
                 defaultMessage: 'Color format',
               },
-              name: 'pluginOptions.color-picker.format',
+              name: 'options.format',
               type: 'select',
               value: 'hex',
               options: [
@@ -217,10 +217,8 @@ When someone adds an attribute to a content type using our “color” custom fi
     "attributeName": {
       "type": "customField",
       "customField": "plugin::color-picker.color",
-      "pluginOptions": {
-        "color-picker": {
-          "format": "hex"
-        }
+      "options": {
+        "format": "hex"
       }
     }
   }


### PR DESCRIPTION
(this is not a new RFC, it's an update to the existing #42)

The `pluginOptions` key is intended for *any* plugin to add options to *any* attribute. Custom fields on the other hand should only apply options to attribute’s with `type: "customField"`. 

We want to provide a more native-like interface. `pluginOptions` looks strange since other plugins (for example i18n) can add options there as well. The custom fields’ options should be more isolated.

Therefore we introduce an options object at the root of the custom field attribute object.