### PR TITLE
Fix some typos in the template and move the `Example` section

### DIFF
--- a/xxxx-template.md
+++ b/xxxx-template.md
@@ -12,27 +12,27 @@ If the proposal requires changes to the current API or the creation of new ones,
 # Motivation
 
 Please make sure to explain the motivation for this proposal. 
-It means explaining the use case(s) and the fonctional feature(s) this proposal is trying to solve. 
+It means explaining the use case(s) and the functional feature(s) this proposal is trying to solve. 
 
-Try to only talk about the intent not the proposed solution here.
+Try to only talk about the intent, not the proposed solution here.
 
 # Detailed design
 
-Describe the proposal in details:
+Describe the proposal in detail:
 
 - Explaining the design so that someone who knows Strapi can understand and someone who works on it can implement the proposal. 
-- Think about edge-cases and include examples.
+- Think about edge cases and include examples.
 
 # Tradeoffs
 
 What potential tradeoffs are involved with this proposal.
 
 - Complexity
-- Work load of implementation
+- Workload of implementation
 - Can this be implemented outside of Strapi's core packages
 - How does this proposal integrate with the current features being implemented
 - Cost of migrating existing Strapi applications (is it a breaking change?)
-- Does implementing this proposal mean reworking teaching resources (videos, tutorials, documentations)?
+- Does implementing this proposal mean reworking teaching resources (videos, tutorials, documentation)?
 
 # Alternatives
 

--- a/xxxx-template.md
+++ b/xxxx-template.md
@@ -5,10 +5,6 @@
 
 Description of the proposed feature or proposed changes.
 
-# Example
-
-If the proposal requires changes to the current API or the creation of new ones, add a basic code example.
-
 # Motivation
 
 Please make sure to explain the motivation for this proposal. 
@@ -22,6 +18,10 @@ Describe the proposal in detail:
 
 - Explaining the design so that someone who knows Strapi can understand and someone who works on it can implement the proposal. 
 - Think about edge cases and include examples.
+
+# Example
+
+If the proposal requires changes to the current API or the creation of new ones, add a basic code example.
 
 # Tradeoffs
 


### PR DESCRIPTION
Fixed some typos in the `xxxx-template.md` file.

I also moved the `Example` section to the area between `Detailed design` and `Tradeoffs`, because I believe it is much easier to understand the examples once you have a clearer overview of the proposed design and of the motivation behind the PR.